### PR TITLE
Add variable block to example and fix spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes (k3s) Terraform installer for Hetzner Cloud
 
-This Terraform module creates a Kubernetes Cluster on Hetzner Cloud infrastructure running Ubuntu 20.04. The cluster is designed to take advantage of the Hetzbner private network, and is equiped with Hetzner specific cluster enhancements.
+This Terraform module creates a Kubernetes Cluster on Hetzner Cloud infrastructure running Ubuntu 20.04. The cluster is designed to take advantage of the Hetzner private network, and is equiped with Hetzner specific cluster enhancements.
 
 Cluster size and instance types are configurable through Terraform variables.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ export TF_VAR_hcloud_token
 Create a `main.tf` file in a new directory with the following contents:
 
 ```hcl
+variable "hcloud_token" {
+  type = string
+}
+
 provider "hcloud" {
   token = var.hcloud_token
 }


### PR DESCRIPTION
Hey folks, I stumbled on this today and decided to give it a try.

I'm running Ubuntu 18.04 in WSL2 (terraform 0.14.4) and without the variable block for `hcloud_token` it won't accept it from env. This tidies up the example so you can copy and paste the code and get up and running quicker. Also I've included a simple spelling fix for Hetzner.