### PR TITLE
Missing versions.tf in the example

### DIFF
--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    hcloud = {
+      source = "hetznercloud/hcloud"
+    }
+  }
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
To run the example module, Terraform v0.14.5 also needs the provider plugin for hcloud.